### PR TITLE
Change deprecated usages and fix code that is broken due to language changes

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -15,8 +15,6 @@ dependencies:
     github: j8r/clicr
   con:
     github: j8r/con
-  cossack:
-    github: crystal-community/cossack
   dynany:
     github: j8r/dynany
   exec:

--- a/spec/cli_spec.cr
+++ b/spec/cli_spec.cr
@@ -101,7 +101,7 @@ describe DPPM::CLI do
     it "cleans unused packages" do
       spec_with_prefix do |prefix|
         build_package prefix.path.to_s
-        Dir.rmdir (prefix.app / "dppm").to_s
+        Dir.delete (prefix.app / "dppm").to_s
         packages = prefix.clean_unused_packages(false) { }
         packages.not_nil!.should eq Set{"libfake_0.0.1", "testapp_0.2.0"}
         Dir.children(prefix.pkg.to_s).should be_empty

--- a/spec/prefix/program_data_task_spec.cr
+++ b/spec/prefix/program_data_task_spec.cr
@@ -108,7 +108,7 @@ describe DPPM::Prefix::ProgramData::Task do
           cmd.execute("mkdir " + tempdir)
           Dir.exists?(tempdir).should be_true
         ensure
-          Dir.rmdir tempdir
+          Dir.delete tempdir
         end
       end
 

--- a/src/logger.cr
+++ b/src/logger.cr
@@ -8,7 +8,7 @@ module DPPM::Logger
   class_property date : Bool = false
 
   def print_date(io)
-    Time.utc.to_s("%F %T%z ", io) if @@date
+    Time.utc.to_s(io, "%F %T%z ") if @@date
   end
 
   def info(title : String, message) : Nil

--- a/src/port_checker.cr
+++ b/src/port_checker.cr
@@ -35,7 +35,7 @@ struct PortChecker
   private def internal_available_port?(socket : IPSocket, port : Int32) : Bool
     socket.bind @ipaddress.address, port
     available = true
-  rescue ex : Errno
+  rescue ex : Socket::BindError | RuntimeError
     available = false
   ensure
     socket.close

--- a/src/service/openrc_config.cr
+++ b/src/service/openrc_config.cr
@@ -101,7 +101,7 @@ class Service::OpenRC::Config < Service::Config
 
     io << "\n\ndepend() {\n\tafter "
     @after << OPENRC_NETWORK_SERVICE
-    @after.join ' ', io
+    @after.join io, ' '
     io << "}\n"
 
     if @reload_signal

--- a/src/service/systemd_config.cr
+++ b/src/service/systemd_config.cr
@@ -107,7 +107,7 @@ class Service::Systemd::Config < Service::Config
 
     @after << SYSTEMD_NETWORK_SERVICE
     systemd["Unit"]["After"] = String.build do |str|
-      @after.join(' ', str) do |service|
+      @after.join(str, ' ') do |service|
         str << service
         str << ".service" if service != SYSTEMD_NETWORK_SERVICE
       end


### PR DESCRIPTION
This still gives a warning when running the specs, due to the inotify dependency still utilizing the deprecated Logger.

This also removes the dependency on cossack, a no-longer-maintained HTTP client, which was only used to follow redirects. That usage has been in-lined into the HTTPHelper.get_string method.